### PR TITLE
Fix plugin-jsdocs proxy support

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/typescript-estree": "5.41.0",
+        "https-proxy-agent": "^5.0.1",
         "node-fetch": "^3.3.2"
       }
     },
@@ -105,6 +106,18 @@
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/array-union": {
@@ -259,6 +272,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/ignore": {
@@ -577,6 +603,14 @@
         }
       }
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -675,6 +709,15 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "ignore": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@typescript-eslint/typescript-estree": "5.41.0",
+    "https-proxy-agent": "^5.0.1",
     "node-fetch": "^3.3.2"
   }
 }

--- a/scripts/plugin-jsdocs.js
+++ b/scripts/plugin-jsdocs.js
@@ -1,8 +1,19 @@
 import { parse } from '@typescript-eslint/typescript-estree';
 import fetch from 'node-fetch';
+import { setDefaultResultOrder } from 'node:dns';
+import HttpsProxyAgent from 'https-proxy-agent';
+
+// Force IPv4 resolution to avoid failures in IPv6-only environments.
+if (typeof setDefaultResultOrder === 'function') {
+    setDefaultResultOrder('ipv4first');
+}
+
+const proxy = process.env.https_proxy || process.env.HTTPS_PROXY ||
+    process.env.http_proxy || process.env.HTTP_PROXY;
+const fetchOptions = proxy ? {agent: new HttpsProxyAgent(proxy)} : {};
 
 // Parse the registry and extract the class methods, parameters and leading comments.
-const response = await fetch('https://raw.githubusercontent.com/mattermost/mattermost/master/webapp/channels/src/plugins/registry.ts');
+const response = await fetch('https://raw.githubusercontent.com/mattermost/mattermost/master/webapp/channels/src/plugins/registry.ts', fetchOptions);
 const registryContent = await response.text();
 const registryParsed = parse(registryContent, { comment: true, loc: true });
 


### PR DESCRIPTION
## Summary
- add https-proxy-agent to allow plugin-jsdocs.js to fetch through configured proxies
- force IPv4 DNS lookup and use proxy agent when available
- detect HTTP(S)_PROXY or http(s)_proxy variables

## Testing
- `npm run test-html` *(fails: html-validate: not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f9094694083338f3e03660f559d72